### PR TITLE
Promisify model methods

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,10 +1,7 @@
 language: node_js
 node_js:
-- '6'
-- '4'
-cache:
-  directories:
-  - node_modules
+  - '6'
+  - '4'
 
 before_install:
   - if [[ `npm -v` != 3* ]]; then npm i -g npm@3; fi

--- a/README.md
+++ b/README.md
@@ -7,14 +7,14 @@ Normally this would be used as an abstract class and extended with your own impl
 
 Implementations would normally define at least a `url` method to define the target of API calls.
 
-There are three methods for API interaction corresponding to GET, POST, and DELETE http methods:
+There are three methods for API interaction corresponding to GET, POST, and DELETE http methods. These methods all return a Promise.
 
 ### `fetch`
 
 ```javascript
 var model = new Model();
-model.fetch(function (err, data, responseTime) {
-    console.log(data);
+model.fetch().then(data => {
+  console.log(data);
 });
 ```
 
@@ -23,10 +23,10 @@ model.fetch(function (err, data, responseTime) {
 ```javascript
 var model = new Model();
 model.set({
-    property: 'properties are sent as JSON request body by default'
+  property: 'properties are sent as JSON request body by default'
 });
-model.save(function (err, data, responseTime) {
-    console.log(data);
+model.save().then(data => {
+  console.log(data);
 });
 ```
 
@@ -35,10 +35,10 @@ The method can also be overwritten by passing options
 ```javascript
 var model = new Model();
 model.set({
-    property: 'this will be sent as a PUT request'
+  property: 'this will be sent as a PUT request'
 });
-model.save({ method: 'PUT' }, function (err, data, responseTime) {
-    console.log(data);
+model.save({ method: 'PUT' }).then(data => {
+  console.log(data);
 });
 ```
 
@@ -46,10 +46,12 @@ model.save({ method: 'PUT' }, function (err, data, responseTime) {
 
 ```javascript
 var model = new Model();
-model.delete(function (err, data) {
-    console.log(data);
+model.delete().then(data => {
+  console.log(data);
 });
 ```
+
+## Options
 
 If no `url` method is defined then the model will use the options parameter and [Node's url.format method](https://nodejs.org/api/url.html#url_url_format_urlobj) to construct a URL.
 
@@ -58,12 +60,12 @@ var model = new Model();
 
 // make a GET request to http://example.com:3000/foo/bar
 model.fetch({
-    protocol: 'http',
-    hostname: 'example.com',
-    port: 3000,
-    path: '/foo/bar'
-}, function (err, data, responseTime) {
-    console.log(data);
+  protocol: 'http',
+  hostname: 'example.com',
+  port: 3000,
+  path: '/foo/bar'
+}).then(data => {
+  console.log(data);
 });
 ```
 

--- a/lib/model.js
+++ b/lib/model.js
@@ -34,10 +34,7 @@ module.exports = class Model extends EventEmitter {
       options = {};
     }
 
-    this.prepare((err, data) => {
-      if (err) {
-        return callback(err);
-      }
+    return this.prepare().then(data => {
       data = JSON.stringify(data);
       const reqConf = this.requestConfig(options);
       reqConf.method = options.method || 'POST';
@@ -60,7 +57,7 @@ module.exports = class Model extends EventEmitter {
     }
     const reqConf = this.requestConfig(options);
     reqConf.method = options.method || 'GET';
-    this.request(reqConf, callback);
+    return this.request(reqConf, callback);
   }
 
   delete(options, callback) {
@@ -72,7 +69,7 @@ module.exports = class Model extends EventEmitter {
     }
     const reqConf = this.requestConfig(options);
     reqConf.method = options.method || 'DELETE';
-    this.request(reqConf, callback);
+    return this.request(reqConf, callback);
   }
 
   requestConfig(options) {
@@ -95,8 +92,9 @@ module.exports = class Model extends EventEmitter {
     settings.body = settings.body || body || settings.data;
 
     settings = _.omit(settings, urlKeys, 'data', 'url');
+    this.emit('sync', originalSettings);
 
-    Promise.resolve().then(() => this.auth()).then((authData) => {
+    const promise = Promise.resolve().then(() => this.auth()).then((authData) => {
       settings.auth = authData;
       if (typeof settings.auth === 'string') {
         let auth = settings.auth.split(':');
@@ -106,45 +104,54 @@ module.exports = class Model extends EventEmitter {
           sendImmediately: true
         };
       }
-    }).then(() => {
+    })
+    .then(() => {
       const startTime = process.hrtime();
       let timeoutTimer;
 
-      const _callback = (err, data, statusCode) => {
-        if (timeoutTimer) {
-          clearTimeout(timeoutTimer);
-          timeoutTimer = null;
-        }
+      return new Promise((resolve, reject) => {
 
-        const endTime = process.hrtime();
-        const responseTime = timeDiff(startTime, endTime);
-
-        if (err) {
-          this.emit('fail', err, data, originalSettings, statusCode, responseTime);
-        } else {
-          this.emit('success', data, originalSettings, statusCode, responseTime);
-        }
-        if (typeof callback === 'function') {
-          callback(err, data, responseTime);
-        }
-      };
-
-      this._request(settings, (err, response) => {
-
-        if (err) {
-          if (err.code === 'ETIMEDOUT') {
-            err.message = 'Connection timed out';
-            err.status = 504;
+        const _callback = (err, data, statusCode) => {
+          if (timeoutTimer) {
+            clearTimeout(timeoutTimer);
+            timeoutTimer = null;
           }
-          err.status = err.status || (response && response.statusCode) || 503;
-          return _callback(err, null, err.status);
-        }
-        return this.handleResponse(response, _callback);
+
+          const endTime = process.hrtime();
+          const responseTime = timeDiff(startTime, endTime);
+
+          if (err) {
+            this.emit('fail', err, data, originalSettings, statusCode, responseTime);
+          } else {
+            this.emit('success', data, originalSettings, statusCode, responseTime);
+          }
+          if (err) {
+            reject(err);
+          } else {
+            resolve(data);
+          }
+        };
+
+        this._request(settings, (err, response) => {
+
+          if (err) {
+            if (err.code === 'ETIMEDOUT') {
+              err.message = 'Connection timed out';
+              err.status = 504;
+            }
+            err.status = err.status || (response && response.statusCode) || 503;
+            return _callback(err, null, err.status);
+          }
+          return this.handleResponse(response, _callback);
+        });
       });
 
     });
 
-    this.emit('sync', originalSettings);
+    if (typeof callback === 'function') {
+      return promise.then((data) => callback(null, data), callback);
+    }
+    return promise;
   }
 
   handleResponse(response, callback) {
@@ -172,8 +179,8 @@ module.exports = class Model extends EventEmitter {
     }
   }
 
-  prepare(callback) {
-    callback(null, this.toJSON());
+  prepare() {
+    return Promise.resolve(this.toJSON());
   }
 
   parse(data) {

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
   "homepage": "https://github.com/UKHomeOfficeForms/hof-model",
   "dependencies": {
     "lodash": "^4.17.2",
-    "request": "^2.72.0"
+    "request": "^2.79.0"
   },
   "devDependencies": {
     "chai": "^3.5.0",


### PR DESCRIPTION
If a callback is not passed into model save/fetch/delete methods then they will return a promise which resolves/rejects accordingly.

Update README to make Promise-based usage the preferred and documented usage.