### PR TITLE
Referenced fields

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,108 @@
 # hof-model
 Simple model for interacting with http/rest apis.
 
-## Usage
+## Data Storage
+
+Models can be used as basic data storage with set/get and change events.
+
+### Methods
+
+#### `set`
+
+Save a property to a model. Properties can be passed as a separate key/value arguments, or with multiple properties as an object.
+
+```javascript
+const model = new Model();
+model.set('key', 'value');
+model.set({
+  firstname: 'John',
+  lastname: 'Smith'
+});
+```
+
+#### `get`
+
+Retrieve a property from a model:
+
+```javascript
+const val = model.get('key');
+// val = 'value'
+```
+
+#### `toJSON`
+
+Returns a map of all properties on a model:
+
+```javascript
+const json = model.toJSON();
+// json = { key: 'value' }
+```
+
+### Events
+
+`change` is emitted when a property on a model changes
+
+```javascript
+const model = new Model();
+model.on('change', (changedFields) => {
+  // changedFields contains a map of the key/value pairs which have changed
+  console.log(changedFields);
+});
+```
+
+`change:<key>` is emitted when a particular property - with a key of `<key>` - on a model changes
+
+```javascript
+const model = new Model();
+model.on('change:name', (newValue, oldValue) => {
+  // handler is passed the new value and the old value as arguents
+});
+model.set('name', 'John Smith');
+```
+
+### Referenced Fields
+
+A field can be set to a reference to another field by setting it a value of `$ref:<key>` where `<key>` is the field to be reference. The field will then behave exactly like a normal field except that its value will always appear as the value of the referenced field.
+
+```javascript
+const model = new Model();
+model.set('home-address', '1 Main Street');
+model.set('contact-address', '$ref:home-address');
+
+model.get('contact-address'); // => '1 Main Street';
+model.set('home-address', '2 Main Street');
+model.get('contact-address'); // => '2 Main Street';
+
+model.toJSON(); // => { home-address: '2 Main Street', 'contact-address': '2 Main Street' }
+```
+
+Change events will be fired on the referenced field if the underlying value changes.
+
+```javascript
+const model = new Model();
+model.set('home-address', '1 Main Street');
+model.set('contact-address', '$ref:home-address');
+model.on('change:contact-address', (value, oldValue) => {
+  // this is fired when home-address property changes
+});
+
+model.set('home-address', '2 Main Street');
+```
+
+A field can be unreferenced by setting its value to any other value.
+
+```javascript
+const model = new Model();
+model.set('home-address', '1 Main Street');
+
+// reference the field
+model.set('contact-address', '$ref:home-address');
+
+// unreference the field
+model.set('contact-address', '1 Other Road');
+```
+
+## API Client
 
 Normally this would be used as an abstract class and extended with your own implementation.
 
@@ -9,19 +110,21 @@ Implementations would normally define at least a `url` method to define the targ
 
 There are three methods for API interaction corresponding to GET, POST, and DELETE http methods. These methods all return a Promise.
 
-### `fetch`
+### Methods
+
+#### `fetch`
 
 ```javascript
-var model = new Model();
+const model = new Model();
 model.fetch().then(data => {
   console.log(data);
 });
 ```
 
-### `save`
+#### `save`
 
 ```javascript
-var model = new Model();
+const model = new Model();
 model.set({
   property: 'properties are sent as JSON request body by default'
 });
@@ -33,7 +136,7 @@ model.save().then(data => {
 The method can also be overwritten by passing options
 
 ```javascript
-var model = new Model();
+const model = new Model();
 model.set({
   property: 'this will be sent as a PUT request'
 });
@@ -42,21 +145,21 @@ model.save({ method: 'PUT' }).then(data => {
 });
 ```
 
-### `delete`
+#### `delete`
 
 ```javascript
-var model = new Model();
+const model = new Model();
 model.delete().then(data => {
   console.log(data);
 });
 ```
 
-## Options
+### Options
 
 If no `url` method is defined then the model will use the options parameter and [Node's url.format method](https://nodejs.org/api/url.html#url_url_format_urlobj) to construct a URL.
 
 ```javascript
-var model = new Model();
+const model = new Model();
 
 // make a GET request to http://example.com:3000/foo/bar
 model.fetch({
@@ -69,7 +172,7 @@ model.fetch({
 });
 ```
 
-## Events
+### Events
 
 API requests will emit events as part of their lifecycle.
 

--- a/lib/model.js
+++ b/lib/model.js
@@ -5,6 +5,8 @@ const request = require('request');
 const url = require('url');
 const EventEmitter = require('events').EventEmitter;
 
+const REFERENCE = /^\$ref:/;
+
 function timeDiff(from, to, digits) {
   if (digits === undefined) {
     digits = 3;
@@ -193,8 +195,17 @@ module.exports = class Model extends EventEmitter {
     }, data);
   }
 
+  resolveReference(value, map) {
+    if (typeof value === 'string' && value.match(REFERENCE)) {
+      const key = value.replace(REFERENCE, '');
+      return _.cloneDeep(map[key]);
+    }
+    return value;
+  }
+
   get(key) {
-    return _.cloneDeep(this.attributes[key]);
+    const value = _.cloneDeep(this.attributes[key]);
+    return this.resolveReference(value, this.attributes);
   }
 
   set(key, value, options) {
@@ -210,14 +221,35 @@ module.exports = class Model extends EventEmitter {
 
     const old = this.toJSON();
     const changed = _.pickBy(attrs, (attr, attrKey) => {
-      return attr !== old[attrKey];
+      return attr !== old[attrKey] || attr !== this.attributes[attrKey];
     });
 
     Object.assign(this.attributes, attrs);
 
+    const references = _.reduce(this.attributes, (map, val, k) => {
+      if (typeof val === 'string' && val.match(REFERENCE)) {
+        const reffed = val.replace(REFERENCE, '');
+        map[reffed] = map[reffed] || [];
+        map[reffed].push(k);
+      }
+      return map;
+    }, {});
+
     if (!options.silent && _.size(changed)) {
       _.each(changed, (changedValue, changedKey) => {
-        this.emit('change:' + changedKey, this.get(changedKey), old[changedKey]);
+        this.emit(`change:${changedKey}`, this.get(changedKey), old[changedKey]);
+        // emit change events for referenced fields
+        if (references[changedKey]) {
+          references[changedKey].forEach(k => {
+            this.emit(`change:${k}`, this.get(changedKey), old[k]);
+          });
+        }
+      });
+      // add references to changed field map
+      _.each(references, (fields, ref) => {
+        fields.forEach(f => {
+          changed[f] = changed[ref];
+        });
       });
       this.emit('change', changed);
     }
@@ -288,6 +320,6 @@ module.exports = class Model extends EventEmitter {
   }
 
   toJSON() {
-    return _.cloneDeep(this.attributes);
+    return _.mapValues(_.cloneDeep(this.attributes), (value, key, attrs) => this.resolveReference(value, attrs));
   }
 };

--- a/test/spec/spec.references.js
+++ b/test/spec/spec.references.js
@@ -45,4 +45,25 @@ describe('Referenced Fields', () => {
     listener.should.have.been.calledWith('new value', 'original value');
   });
 
+  it('unreferencing a field emits a change event even if the raw value is unchanged', () => {
+    const listener1 = sinon.stub();
+    const listener2 = sinon.stub();
+    model.on('change:reffed', listener1);
+    model.on('change', listener2);
+    model.set('reffed', 'original value');
+    listener1.should.have.been.calledWith('original value');
+    listener2.should.have.been.calledWith({ reffed: 'original value' });
+  });
+
+  it('unreferencing a field no longer emits change events on changes to the referenced field', () => {
+    const listener = sinon.stub();
+    model.on('change:reffed', listener);
+    model.set('parent', 'new value 1');
+    listener.should.have.been.calledOnce;
+    model.set('reffed', 'unref');
+    listener.should.have.been.calledTwice;
+    model.set('parent', 'new value 2');
+    listener.should.have.been.calledTwice;
+  });
+
 });

--- a/test/spec/spec.references.js
+++ b/test/spec/spec.references.js
@@ -1,0 +1,48 @@
+'use strict';
+
+const Model = require('../../');
+
+describe('Referenced Fields', () => {
+  let model;
+
+  beforeEach(() => {
+    model = new Model();
+    model.set('parent', 'original value');
+    model.set('reffed', '$ref:parent');
+  });
+
+  it('`get` returns the referenced field value', () => {
+    model.get('reffed').should.equal('original value');
+  });
+
+  it('`toJSON` returns the referenced field value', () => {
+    model.toJSON().reffed.should.equal('original value');
+  });
+
+  it('`get` returns referenced field value after a change', () => {
+    model.get('reffed').should.equal('original value');
+    model.set('parent', 'new value');
+    model.get('reffed').should.equal('new value');
+  });
+
+  it('`toJSON` returns referenced field value after a change', () => {
+    model.toJSON().reffed.should.equal('original value');
+    model.set('parent', 'new value');
+    model.toJSON().reffed.should.equal('new value');
+  });
+
+  it('emits change events for referenced fields when referenced value changes', () => {
+    const listener = sinon.stub();
+    model.on('change', listener);
+    model.set('parent', 'new value');
+    listener.should.have.been.calledWith({ parent: 'new value', reffed: 'new value' });
+  });
+
+  it('emits field specific change events for referenced fields when referenced value changes', () => {
+    const listener = sinon.stub();
+    model.on('change:reffed', listener);
+    model.set('parent', 'new value');
+    listener.should.have.been.calledWith('new value', 'original value');
+  });
+
+});


### PR DESCRIPTION
Allows a field to be set to a reference to another field, and be kept in sync with changes to the value of the dependent field.

```js
const model = new Model();
model.set('home-address', '1 Main Street');
model.set('contact-address', '$ref:home-address');

model.get('contact-address'); // => '1 Main Street'
```