### PR TITLE
Handle `ESOCKETTIMEDOUT` errors

### DIFF
--- a/lib/model.js
+++ b/lib/model.js
@@ -139,7 +139,7 @@ module.exports = class Model extends EventEmitter {
         this._request(settings, (err, response) => {
 
           if (err) {
-            if (err.code === 'ETIMEDOUT') {
+            if (err.code === 'ETIMEDOUT' || err.code === 'ESOCKETTIMEDOUT') {
               err.message = 'Connection timed out';
               err.status = 504;
             }


### PR DESCRIPTION
The request module can send different error codes depending on whether the socket connection times out, or no data is returned to an already connected socket. See https://github.com/request/request/blob/b12a6245d9acdb1e13c6486d427801e123fdafae/request.js#L804-L855

Handle both of these.